### PR TITLE
small ux proposal / update

### DIFF
--- a/client/components/SearchWindow/SearchBox.jsx
+++ b/client/components/SearchWindow/SearchBox.jsx
@@ -34,9 +34,25 @@ const SearchBox = () => {
 	return (
 		<SearchBoxWrapper>
 			<SearchBoxTitle>Search</SearchBoxTitle>
+
 			<SearchInputAndTextWrapper>
 				<SearchBoxP>
-					Enter an address below to build your swap offer
+					NFT Conatract Address
+				</SearchBoxP>
+				<form onSubmit={handleSubmit}>
+					<SearchInputWrapper>
+						<SearchBoxInput
+							onChange={handleInputChange}
+							name='addressToSearch'
+							required
+						/>
+						<SearchBoxSubmit />
+					</SearchInputWrapper>
+				</form>
+			</SearchInputAndTextWrapper>
+			<SearchInputAndTextWrapper>
+				<SearchBoxP>
+					User Public Key or ENS
 				</SearchBoxP>
 				<form onSubmit={handleSubmit}>
 					<SearchInputWrapper>


### PR DESCRIPTION
Instead of just having one search bar, It might might make more sense to have 2. 

1. For searching user address / key
2. For searching NFT contract address

This way depending on which one they search it will bring back a different result / screen of a list of either token's minted (contract) or tokens owned (user) along with sorting weather or not it's listed. 

You could have it  just automatically do that with one search bar however, I genuinely believe people don't even know the difference between a user public key and a smart contract public key. Making it knowen visually that there is a difference (hence the 2 search bars) might help establish that.  