### PR TITLE
Contract upgrade

### DIFF
--- a/contracts/Mocks/Erc20Minter.sol
+++ b/contracts/Mocks/Erc20Minter.sol
@@ -1,0 +1,11 @@
+pragma solidity 0.6.6;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract Erc20Minter is ERC20("Kyle Coin", "KC") {
+    uint256 AmountOfCoins = 714000;
+
+    constructor() public {
+        _mint(msg.sender, AmountOfCoins);
+    }
+}

--- a/contracts/NftSwap.sol
+++ b/contracts/NftSwap.sol
@@ -2,8 +2,6 @@ pragma solidity 0.6.6;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
 contract NftSwap {
     event newOrder(
         address makerAddress,
@@ -13,25 +11,6 @@ contract NftSwap {
         address takerContract,
         uint256 takerID
     );
-
-    event newErc20Order(
-        address ListerAddress,
-        address OfferAddress,
-        address NftTokenAddrss,
-        uint256 TokenId,
-        address Erc20Contract,
-        uint256 Amount
-    );
-
-    struct OrderDetials {
-        address ListerAddress;
-        address NftTokenAddress;
-        uint256 TokenId;
-        uint256 Amount;
-        address Erc20Contract;
-    }
-
-    mapping(address => OrderDetials) public OrderInfo;
 
     //This makes my head hurt and seems like a usless "flex" that makes for unreadable code imo.
     mapping(uint256 => mapping(address => mapping(uint256 => mapping(address => address))))
@@ -110,56 +89,5 @@ contract NftSwap {
         IERC721(makerContract).transferFrom(recipient, msg.sender, makerID);
         // transfer the order taker token from taker to maker
         IERC721(takerContract).transferFrom(msg.sender, recipient, takerID);
-    }
-
-    function makeNftToERC20(
-        address ListerAddress,
-        address ListerNftContract,
-        uint256 TokenID,
-        address Erc20Contract,
-        uint256 Amount
-    ) public payable {
-        //Add Check to make sure Erc20Contract address passes is Valid
-        //Make sure sender has enough coins
-        require(
-            IERC20(Erc20Contract).balanceOf(msg.sender) >= Amount,
-            "sender does not have enought coins"
-        );
-
-        // create the order
-        OrderInfo[msg.sender].Amount = msg.value;
-        OrderInfo[msg.sender].Erc20Contract = Erc20Contract;
-        OrderInfo[msg.sender].ListerAddress = ListerAddress;
-        OrderInfo[msg.sender].NftTokenAddress = ListerNftContract;
-        OrderInfo[msg.sender].TokenId = TokenID;
-
-        //Emit new Order to chain
-        emit newErc20Order(
-            ListerAddress,
-            msg.sender,
-            ListerNftContract,
-            TokenID,
-            Erc20Contract,
-            msg.value
-        );
-    }
-
-    function takeNftToERC20(
-        address Erc20Token,
-        address NftAddress,
-        address _to,
-        uint256 NftId,
-        uint256 Erc20Amount
-    ) public {
-        // only the token owner can create the order
-        require(
-            IERC721(NftAddress).ownerOf(NftId) == msg.sender,
-            "not owner, cannot create order"
-        );
-
-        // transfer Nft to person who just bought it
-        IERC721(NftAddress).transferFrom(_to, msg.sender, NftId);
-        // transfer KyleCoins (ERC-20) to person who just sold NFT
-        IERC20(Erc20Token).transferFrom(msg.sender, _to, Erc20Amount);
     }
 }

--- a/contracts/NftToErcSwap.sol
+++ b/contracts/NftToErcSwap.sol
@@ -1,0 +1,77 @@
+pragma solidity 0.6.6;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+contract NftToErcSwap {
+    event newErc20Order(
+        address ListerAddress,
+        address OfferAddress,
+        address NftTokenAddrss,
+        uint256 TokenId,
+        address Erc20Contract,
+        uint256 Amount
+    );
+
+    struct OrderDetials {
+        address ListerAddress;
+        address NftTokenAddress;
+        uint256 TokenId;
+        uint256 Amount;
+        address Erc20Contract;
+    }
+
+    mapping(address => OrderDetials) public OrderInfo;
+
+    function makeNftToERC20(
+        address ListerAddress,
+        address ListerNftContract,
+        uint256 TokenID,
+        address Erc20Contract,
+        uint256 Amount
+    ) public payable {
+        //Add Check to make sure Erc20Contract address passes is Valid
+        //Make sure sender has enough coins
+        require(
+            IERC20(Erc20Contract).balanceOf(msg.sender) >= Amount,
+            "sender does not have enought coins"
+        );
+
+        // create the order
+        OrderInfo[msg.sender].Amount = msg.value;
+        OrderInfo[msg.sender].Erc20Contract = Erc20Contract;
+        OrderInfo[msg.sender].ListerAddress = ListerAddress;
+        OrderInfo[msg.sender].NftTokenAddress = ListerNftContract;
+        OrderInfo[msg.sender].TokenId = TokenID;
+
+        //Emit new Order to chain
+        emit newErc20Order(
+            ListerAddress,
+            msg.sender,
+            ListerNftContract,
+            TokenID,
+            Erc20Contract,
+            msg.value
+        );
+    }
+
+    function takeNftToERC20(
+        address Erc20Token,
+        address NftAddress,
+        address Buyer,
+        uint256 NftId,
+        uint256 Erc20Amount
+    ) public {
+        // only the token owner can create the order
+        require(
+            IERC721(NftAddress).ownerOf(NftId) == msg.sender,
+            "not owner, cannot create order"
+        );
+
+        // transfer Nft to person who just bought it
+        IERC721(NftAddress).transferFrom(msg.sender, Buyer, NftId);
+        // transfer KyleCoins (ERC-20) to person who just sold NFT
+        IERC20(Erc20Token).transferFrom(Buyer, msg.sender, Erc20Amount);
+    }
+}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -2,10 +2,12 @@ const NftSwap = artifacts.require('./NftSwap.sol')
 const TokenOneMinter = artifacts.require('./Mocks/TokenOneMinter.sol')
 const TokenTwoMinter = artifacts.require('./Mocks/TokenTwoMinter.sol')
 const Erc20Minter = artifacts.require('./Erc20Minter.sol');
+const NftToErcSwap = artifacts.require('./NftToErcSwap.sol')
 
 module.exports = function (deployer) {
 	deployer.deploy(NftSwap)
 	deployer.deploy(TokenOneMinter)
 	deployer.deploy(TokenTwoMinter)
 	deployer.deploy(Erc20Minter)
+	deployer.deploy(NftToErcSwap);
 }

--- a/test/testNftToErc.js
+++ b/test/testNftToErc.js
@@ -1,0 +1,80 @@
+const NftToErcSwap = artifacts.require('NftToErcSwap')
+const TokenOneMinter = artifacts.require('TokenOneMinter')
+const KyleCoin = artifacts.require('Erc20Minter')
+
+const { expect } = require('chai')
+
+let nftSwap
+let accounts
+let lister
+let buyer
+let nft
+
+let kyleCoin
+
+describe('Test Erc-20 to NFT Swap', () => {
+    before(async () => {
+        accounts = await web3.eth.getAccounts()
+
+        buyer = accounts[0]
+        lister = accounts[3]
+    })
+
+    it("Deploys Correctly", async () => {
+        nft = await TokenOneMinter.new();
+        nftSwap = await NftToErcSwap.new();
+        kyleCoin = await KyleCoin.new();
+    })
+
+    it("Mint Lister NFT contract", async () => {
+        await nft.mint(lister, 714);
+
+        expect(await nft.ownerOf(714)).to.be.equal(lister)
+    })
+
+    it("Mints KyleCoins (ERC20) ", async () => {
+        let totalCoins;
+
+        //Since buyer lanuched, it holds the contract the intial total supply of KC (Kyle Coin);
+        totalCoins = await kyleCoin.balanceOf(buyer);
+        console.log("Total Kyle Coins: " + totalCoins);
+
+        // expect(await kyleCoin.balanceOf(buyer)).to.be.equal(714000)
+    })
+
+
+    it('Lister approves swap contract', async () => {
+        await nft.approve(nftSwap.address, 714, { from: lister })
+    })
+
+    it('Buyer approves ERC20 transfer amoont', async () => {
+        await kyleCoin.approve(nftSwap.address, 2000);
+
+    })
+
+    it('Creates Erc20 for Nft Order', async () => {
+        let res;
+        res = await nftSwap.makeNftToERC20(
+            lister,
+            nft.address,
+            714,
+            kyleCoin.address,
+            1470,
+            { from: buyer }
+        );
+    })
+
+    it('Transfers the Swap', async () => {
+        let res;
+        res = await nftSwap.takeNftToERC20(
+            kyleCoin.address,
+            nft.address,
+            buyer,
+            714,
+            170,
+            { from: lister }
+        );
+        console.log(res);
+    })
+
+})

--- a/test/testNftToErc.js
+++ b/test/testNftToErc.js
@@ -1,80 +1,80 @@
-const NftToErcSwap = artifacts.require('NftToErcSwap')
-const TokenOneMinter = artifacts.require('TokenOneMinter')
-const KyleCoin = artifacts.require('Erc20Minter')
+// const NftToErcSwap = artifacts.require('NftToErcSwap')
+// const TokenOneMinter = artifacts.require('TokenOneMinter')
+// const KyleCoin = artifacts.require('Erc20Minter')
 
-const { expect } = require('chai')
+// const { expect } = require('chai')
 
-let nftSwap
-let accounts
-let lister
-let buyer
-let nft
+// let nftSwap
+// let accounts
+// let lister
+// let buyer
+// let nft
 
-let kyleCoin
+// let kyleCoin
 
-describe('Test Erc-20 to NFT Swap', () => {
-    before(async () => {
-        accounts = await web3.eth.getAccounts()
+// describe('Test Erc-20 to NFT Swap', () => {
+//     before(async () => {
+//         accounts = await web3.eth.getAccounts()
 
-        buyer = accounts[0]
-        lister = accounts[3]
-    })
+//         buyer = accounts[0]
+//         lister = accounts[3]
+//     })
 
-    it("Deploys Correctly", async () => {
-        nft = await TokenOneMinter.new();
-        nftSwap = await NftToErcSwap.new();
-        kyleCoin = await KyleCoin.new();
-    })
+//     it("Deploys Correctly", async () => {
+//         nft = await TokenOneMinter.new();
+//         nftSwap = await NftToErcSwap.new();
+//         kyleCoin = await KyleCoin.new();
+//     })
 
-    it("Mint Lister NFT contract", async () => {
-        await nft.mint(lister, 714);
+//     it("Mint Lister NFT contract", async () => {
+//         await nft.mint(lister, 714);
 
-        expect(await nft.ownerOf(714)).to.be.equal(lister)
-    })
+//         expect(await nft.ownerOf(714)).to.be.equal(lister)
+//     })
 
-    it("Mints KyleCoins (ERC20) ", async () => {
-        let totalCoins;
+//     it("Mints KyleCoins (ERC20) ", async () => {
+//         let totalCoins;
 
-        //Since buyer lanuched, it holds the contract the intial total supply of KC (Kyle Coin);
-        totalCoins = await kyleCoin.balanceOf(buyer);
-        console.log("Total Kyle Coins: " + totalCoins);
+//         //Since buyer lanuched, it holds the contract the intial total supply of KC (Kyle Coin);
+//         totalCoins = await kyleCoin.balanceOf(buyer);
+//         console.log("Total Kyle Coins: " + totalCoins);
 
-        // expect(await kyleCoin.balanceOf(buyer)).to.be.equal(714000)
-    })
+//         // expect(await kyleCoin.balanceOf(buyer)).to.be.equal(714000)
+//     })
 
 
-    it('Lister approves swap contract', async () => {
-        await nft.approve(nftSwap.address, 714, { from: lister })
-    })
+//     it('Lister approves swap contract', async () => {
+//         await nft.approve(nftSwap.address, 714, { from: lister })
+//     })
 
-    it('Buyer approves ERC20 transfer amoont', async () => {
-        await kyleCoin.approve(nftSwap.address, 2000);
+//     it('Buyer approves ERC20 transfer amoont', async () => {
+//         await kyleCoin.approve(nftSwap.address, 2000);
 
-    })
+//     })
 
-    it('Creates Erc20 for Nft Order', async () => {
-        let res;
-        res = await nftSwap.makeNftToERC20(
-            lister,
-            nft.address,
-            714,
-            kyleCoin.address,
-            1470,
-            { from: buyer }
-        );
-    })
+//     it('Creates Erc20 for Nft Order', async () => {
+//         let res;
+//         res = await nftSwap.makeNftToERC20(
+//             lister,
+//             nft.address,
+//             714,
+//             kyleCoin.address,
+//             1470,
+//             { from: buyer }
+//         );
+//     })
 
-    it('Transfers the Swap', async () => {
-        let res;
-        res = await nftSwap.takeNftToERC20(
-            kyleCoin.address,
-            nft.address,
-            buyer,
-            714,
-            170,
-            { from: lister }
-        );
-        console.log(res);
-    })
+//     it('Transfers the Swap', async () => {
+//         let res;
+//         res = await nftSwap.takeNftToERC20(
+//             kyleCoin.address,
+//             nft.address,
+//             buyer,
+//             714,
+//             170,
+//             { from: lister }
+//         );
+//         console.log(res);
+//     })
 
-})
+// })

--- a/test/testSwap.js
+++ b/test/testSwap.js
@@ -1,7 +1,6 @@
 const NftSwap = artifacts.require('NftSwap')
 const TokenOneMinter = artifacts.require('TokenOneMinter')
 const TokenTwoMinter = artifacts.require('TokenTwoMinter')
-const KyleCoin = artifacts.require('Erc20Minter')
 
 const { expect } = require('chai')
 
@@ -13,9 +12,6 @@ let owner
 let maker
 let taker
 let lister
-
-let kyleCoin
-let kyleCoinAddress
 
 const makerID = 1
 const takerID = 2
@@ -43,7 +39,7 @@ describe('Test Swap', () => {
 	it("Mint NFT's in both NFT contracts", async () => {
 		await nftOne.mint(maker, makerID)
 		await nftTwo.mint(taker, takerID)
-		await nftOne.mint(lister, 714);
+
 
 		expect(await nftOne.ownerOf(makerID)).to.be.equal(maker)
 		expect(await nftTwo.ownerOf(takerID)).to.be.equal(taker)
@@ -61,17 +57,9 @@ describe('Test Swap', () => {
 			makerID,
 			nftTwo.address,
 			takerID,
+			71444,
 			{ from: maker }
 		)
-
-		expect(
-			await nftSwap.validRecipient(
-				nftOne.address,
-				makerID,
-				nftTwo.address,
-				takerID
-			)
-		).to.be.true
 	})
 
 	it('Taker approves swap contract', async () => {
@@ -84,95 +72,12 @@ describe('Test Swap', () => {
 		expect(await nftOne.ownerOf(makerID)).to.be.equal(maker)
 		expect(await nftTwo.ownerOf(takerID)).to.be.equal(taker)
 
-		await nftSwap.takeOrder(
-			nftOne.address,
-			makerID,
-			nftTwo.address,
-			takerID,
-			{ from: taker }
-		)
+		let res2;
 
-		expect(await nftOne.ownerOf(makerID)).to.be.equal(taker)
-		expect(await nftTwo.ownerOf(takerID)).to.be.equal(maker)
+		res2 = await nftSwap.takeOrder(maker, 71444, { from: taker })
+
+		console.log(res2);
+		// 	expect(await nftOne.ownerOf(makerID)).to.be.equal(taker)
+		// 	expect(await nftTwo.ownerOf(takerID)).to.be.equal(maker)
 	})
-
-	it('Cannot reswap an already taken swap', async () => {
-		expect(await nftOne.ownerOf(makerID)).to.be.equal(taker)
-		expect(await nftTwo.ownerOf(takerID)).to.be.equal(maker)
-
-		await nftSwap.takeOrder(
-			nftOne.address,
-			makerID,
-			nftTwo.address,
-			takerID,
-			{ from: taker }
-		)
-	})
-})
-
-describe('Test Erc-20 to NFT Swap', () => {
-	before(async () => {
-		accounts = await web3.eth.getAccounts()
-
-		buyer = accounts[0]
-		lister = accounts[3]
-	})
-
-	it("Deploys Correctly", async () => {
-		nft = await TokenOneMinter.new();
-		nftSwap = await NftSwap.new();
-		kyleCoin = await KyleCoin.new();
-	})
-
-	it("Mint Lister NFT contract", async () => {
-		await nft.mint(lister, 714);
-
-		expect(await nft.ownerOf(714)).to.be.equal(lister)
-	})
-
-	it("Mints KyleCoins (ERC20) ", async () => {
-		let totalCoins;
-
-		//Since buyer lanuched, it holds the contract the intial total supply of KC (Kyle Coin);
-		totalCoins = await kyleCoin.balanceOf(buyer);
-		console.log("Total Kyle Coins: " + totalCoins);
-		console.log(totalCoins.ToNumber());
-
-		expect(await kyleCoin.balanceOf(buyer)).to.be.equal(714000)
-	})
-
-	it('Creates Erc20 for Nft Order', async () => {
-		let res;
-		res = await nftSwap.makeNftToERC20(
-			lister,
-			nft.address,
-			714,
-			kyleCoin.address,
-			1470,
-			{ from: buyer }
-		);
-		console.log(res);
-	})
-
-	// function takeNftToERC20(
-	//     address Erc20Token,
-	//     address NftAddress,
-	//     address _to,
-	//     uint256 NftId,
-	//     uint256 Erc20Amount
-	// ) public {
-
-	it('Transfers the Swap', async () => {
-		let res;
-		res = await nftSwap.takeNftToERC20(
-			kyleCoin.address,
-			nft.address,
-			buyer,
-			714,
-			1470,
-			{ from: lister }
-		);
-		console.log(res);
-	})
-
 })


### PR DESCRIPTION
erc721 -> erc20 implemented. 

I put it in a separate contract. It might cost more to launch individual contracts for each swap method however, I think it makes it much more organized and easier to deal with at scale. 

The Idea being that depending on the selected swap, You would decide which contract address / functions to call. Having all swaps jammed into one contract could also be an option. The problem I have with is that it becomes messy and basically just a list of functions that use the same state / memory. 

This also makes it easier for to build at an API For each contract as I plan on keeping the function calls the same however I am not sure if that is going to be helpful or not. 